### PR TITLE
Token default settings fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,6 @@
       "properties": {
         "vcslack.selfToken": {
           "type": "array",
-          "default": [
-            "your slack token 1",
-            "your slack token 2"
-          ],
           "description": "Specify the tokens of your slack team"
         }
       }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,5 +1,7 @@
 import { SlackFileTypes } from './types/vcslack'
 
+export const defaultTokens = ['your slack token 1', 'your slack token 2']
+
 export const filetypeMap: SlackFileTypes = {
   plaintext: {
     slackCompatible: 'text'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,25 @@ export const activate = async (context: vscode.ExtensionContext) => {
 
   if (!tokens) {
     vscode.window.showErrorMessage(
-      'VCSlack: You should probably add some Slack tokens!'
+      `VCSlack: You should probably add some Slack tokens!
+        1. Go to settings
+        2. Search for "vcslack"
+        3. Click edit in settings.json
+        4. Add VCSlack setting in following format:
+          "vcslack.selfToken": [
+            "xoxp-358484..."
+          ]`
+    )
+  } else if (Array.isArray(tokens) && tokens.length === 0) {
+    vscode.window.showErrorMessage(
+      `VCSlack: You should probably add some Slack tokens!
+        1. Go to settings
+        2. Search for "vcslack"
+        3. Click edit in settings.json
+        4. Add VCSlack setting in following format:
+          "vcslack.selfToken": [
+            "xoxp-358484...
+          ]`
     )
   } else {
     context.globalState.update('tokens', tokens)


### PR DESCRIPTION
Issues referencing:

#3 

Issue:
Default token settings were technically a token that didn't post because it was just a string.

Solution:
Remove default tokens, add for catches for empty token params.